### PR TITLE
Update BOM

### DIFF
--- a/250916_schematic-pcb-error-report.txt
+++ b/250916_schematic-pcb-error-report.txt
@@ -1,0 +1,342 @@
+Info: Processing symbol 'J15:Connector_USB:USB_C_Receptacle_Molex_105450-0101'.
+Info: Processing symbol 'J6:libreboard:216989-0001_MOL'.
+Info: Processing symbol 'U18:Package_TO_SOT_SMD:SOT-23-5'.
+Info: Processing symbol 'U15:Package_TO_SOT_SMD:SOT-23-6'.
+Info: Processing symbol 'J7:CM5IO:SDCARD_MOLEX_503398-1892'.
+Info: Processing symbol 'J8:Connector_PinHeader_2.54mm:PinHeader_2x20_P2.54mm_Vertical'.
+Info: Processing symbol 'J10:libreboard:216989-0001_MOL'.
+Info: Processing symbol 'U14:libreboard:RYQ0021A-MFG'.
+Info: Processing symbol 'U13:Package_TO_SOT_SMD:SOT-23-5'.
+Info: Processing symbol 'U12:Package_TO_SOT_SMD:TSOT-23_HandSoldering'.
+Info: Processing symbol 'J11:Connector_USB:USB_C_Receptacle_GCT_USB4105-GF-A_16P_TopMnt_Horizontal'.
+Info: Processing symbol 'U11:Package_QFP:HTQFP-64-1EP_10x10mm_P0.5mm_EP8x8mm_Mask4.4x4.4mm_ThermalVias'.
+Info: Processing symbol 'J14:Connector_JST:JST_SH_BM04B-SRSS-TB_1x04-1MP_P1.00mm_Vertical'.
+Info: Processing symbol 'U10:Package_DFN_QFN:Texas_RGV0016A_VQFN-16-1EP_4x4mm_P0.65mm_EP2.1x2.1mm_ThermalVias'.
+Info: Processing symbol 'U9:CM5IO:LED-SMD_4P-L4.0-W1.6-L'.
+Info: Processing symbol 'BT1:CM5IO:BatteryHolder_Keystone_3034_1x20mm'.
+Info: Processing symbol 'J16:Connector_JST:JST_SH_BM04B-SRSS-TB_1x04-1MP_P1.00mm_Vertical'.
+Info: Processing symbol 'U8:Package_DFN_QFN:DFN-8-1EP_2x2mm_P0.5mm_EP1.05x1.75mm'.
+Info: Processing symbol 'J17:libreboard:216989-0001_MOL'.
+Info: Processing symbol 'U7:Crystal:Crystal_SMD_3225-4Pin_3.2x2.5mm'.
+Info: Processing symbol 'U6:Package_TO_SOT_SMD:SOT-23-6'.
+Info: Processing symbol 'J19:Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical'.
+Info: Processing symbol 'J22:CM5IO:EDAC 690-019-298-412'.
+Info: Processing symbol 'J51:libreboard:CONN_SD-47053-001_H10p00_MOL'.
+Info: Processing symbol 'J52:libreboard:CONN_SD-47053-001_H10p00_MOL'.
+Info: Processing symbol 'J53:libreboard:CONN_SD-47053-001_H10p00_MOL'.
+Info: Processing symbol 'J54:libreboard:CONN_SD-47053-001_H10p00_MOL'.
+Info: Processing symbol 'J100:libreboard:KEYSTONE_7790'.
+Info: Processing symbol 'U5:Package_TO_SOT_SMD:SOT-353_SC-70-5'.
+Info: Processing symbol 'H1:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'C62:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C63:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C64:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C65:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C66:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C67:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C68:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C69:Capacitor_SMD:CP_Elec_6.3x9.9'.
+Info: Processing symbol 'D1:LED_SMD:LED_0603_1608Metric'.
+Info: Processing symbol 'D2:LED_SMD:LED_0603_1608Metric'.
+Info: Processing symbol 'D3:LED_SMD:LED_0603_1608Metric'.
+Info: Processing symbol 'FB1:libreboard:BEADC1005X55N'.
+Info: Processing symbol 'FB2:libreboard:BEADC1005X55N'.
+Info: Processing symbol 'U4:libreboard:RYQ0021A-MFG'.
+Info: Processing symbol 'H2:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H3:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H4:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H5:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H6:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H7:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'H8:libreboard:MountingHole_2.7mm_M2.5_DIN965'.
+Info: Processing symbol 'J1:libreboard:216989-0001_MOL'.
+Info: Processing symbol 'J2:Connector_PinHeader_2.54mm:PinHeader_2x07_P2.54mm_Vertical'.
+Info: Processing symbol 'J3:Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical'.
+Info: Processing symbol 'J4:CM5IO:M.2 M Key socket'.
+Info: Processing symbol 'J5:CM5IO:Hirose_FH12-22S-0.5SH_1x22-1MP_P0.50mm_Horizontal'.
+Info: Processing symbol 'Y1:Oscillator:Oscillator_SMD_ECS_2520MV-xxx-xx-4Pin_2.5x2.0mm'.
+Info: Processing symbol 'R34:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R21:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R22:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R23:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R24:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R25:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R26:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R27:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R28:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R29:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R30:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R31:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R32:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R33:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R20:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R35:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R36:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R37:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R38:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R39:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R40:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R41:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R46:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'SW1:Button_Switch_THT:SW_Tactile_SPST_Angled_PTS645Vx58-2LFS'.
+Info: Processing symbol 'SW2:Button_Switch_THT:SW_Tactile_SPST_Angled_PTS645Vx31-2LFS'.
+Info: Processing symbol 'TP1:TestPoint:TestPoint_Pad_2.0x2.0mm'.
+Info: Processing symbol 'TP3:TestPoint:TestPoint_Pad_2.0x2.0mm'.
+Info: Processing symbol 'TP5:TestPoint:TestPoint_Pad_2.0x2.0mm'.
+Info: Processing symbol 'R6:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'J101:libreboard:KEYSTONE_7790'.
+Info: Processing symbol 'U3:CM5IO:TRJG0926HENL'.
+Info: Processing symbol 'U2:Package_SON:USON-10_2.5x1.0mm_P0.5mm'.
+Info: Processing symbol 'L1:CM5IO:L_Bourns_SRP5030CC'.
+Info: Processing symbol 'U1:Package_SON:USON-10_2.5x1.0mm_P0.5mm'.
+Info: Processing symbol 'L2:Inductor_SMD:L_Bourns_SRN8040TA'.
+Info: Processing symbol 'L3:Inductor_SMD:L_Bourns_SRN8040TA'.
+Info: Processing symbol 'Module1:CM5IO:Raspberry-Pi-5-Compute-Module'.
+Info: Processing symbol 'R1:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R2:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R3:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R4:Resistor_SMD:R_0805_2012Metric_Pad1.20x1.40mm_HandSolder'.
+Info: Processing symbol 'R5:Resistor_SMD:R_0805_2012Metric_Pad1.20x1.40mm_HandSolder'.
+Info: Total warnings: 34, errors: 10.
+Info: Processing symbol 'R7:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R8:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R9:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R10:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R11:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R12:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R13:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R14:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R15:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R16:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R17:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R18:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'R19:Resistor_SMD:R_0402_1005Metric'.
+Info: Processing symbol 'C46:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C40:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C20:Capacitor_SMD:CP_Elec_8x6.7'.
+Info: Processing symbol 'C41:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C42:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C19:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C43:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C44:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C18:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C45:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C39:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C17:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C47:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C16:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C48:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C15:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C49:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C14:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C13:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C50:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C33:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C26:Capacitor_SMD:CP_Elec_5x5.9'.
+Info: Processing symbol 'C25:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C27:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C28:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C29:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C30:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C24:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C31:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C32:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C61:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C34:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C35:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C23:Capacitor_SMD:C_1206_3216Metric'.
+Info: Processing symbol 'C36:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C37:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C22:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C38:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C21:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C4:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C53:Capacitor_SMD:C_1206_3216Metric'.
+Info: Processing symbol 'C8:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C7:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C54:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C6:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C55:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C56:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C5:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C12:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C57:Capacitor_Tantalum_SMD:CP_EIA-7343-31_Kemet-D'.
+Info: Processing symbol 'C3:Capacitor_Tantalum_SMD:CP_EIA-7343-31_Kemet-D'.
+Info: Processing symbol 'C58:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C2:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C59:Capacitor_SMD:C_0805_2012Metric'.
+Info: Processing symbol 'C60:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C1:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C9:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C10:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C11:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C52:Capacitor_SMD:C_0402_1005Metric'.
+Info: Processing symbol 'C51:Capacitor_SMD:CP_Elec_6.3x5.9'.
+Update R5 fields.
+Update R6 fields.
+Update C22 fields.
+Update C3 fields.
+Update R4 fields.
+Update C14 fields.
+Update R46 fields.
+Update R3 fields.
+Change C23 footprint from 'Capacitor_SMD:C_0402_1005Metric' to 'Capacitor_SMD:C_1206_3216Metric'.
+Update R20 fields.
+Update R2 fields.
+Update C2 fields.
+Update SW1 fields.
+Update C23 fields.
+Update C13 fields.
+Update R1 fields.
+Update SW2 fields.
+Update C1 fields.
+Update Module1 fields.
+Update TP5 fields.
+Update TP1 fields.
+Update C12 fields.
+Update TP3 fields.
+Update C35 fields.
+Update C9 fields.
+Update R15 fields.
+Update C16 fields.
+Update C8 fields.
+Update R14 fields.
+Update C17 fields.
+Update R16 fields.
+Update R13 fields.
+Update C7 fields.
+Update R12 fields.
+Update C18 fields.
+Update R11 fields.
+Update C6 fields.
+Update R19 fields.
+Update R10 fields.
+Update R17 fields.
+Update C19 fields.
+Update R9 fields.
+Update C15 fields.
+Update C5 fields.
+Update R8 fields.
+Update R18 fields.
+Update C20 fields.
+Update R7 fields.
+Update C4 fields.
+Update C10 fields.
+
+Update H4 fields.
+Update H5 fields.
+Update C51 fields.
+Update H6 fields.
+Update H7 fields.
+Update C50 fields.
+Update H8 fields.
+
+Update H3 fields.
+Update C63 fields.
+Update C60 fields.
+Update C49 fields.
+Update J2 fields.
+Update J3 fields.
+Update C48 fields.
+Update C62 fields.
+Update J4 fields.
+Update D1 fields.
+Update C64 fields.
+Update C59 fields.
+Update C66 fields.
+Update C58 fields.
+Update C67 fields.
+Update C68 fields.
+Update C57 fields.
+Update C69 fields.
+Update C26 fields.
+Update C56 fields.
+Update D2 fields.
+Update D3 fields.
+Update C54 fields.
+Update H1 fields.
+Update C53 fields.
+Update H2 fields.
+Change C53 footprint from 'Capacitor_SMD:C_0402_1005Metric' to 'Capacitor_SMD:C_1206_3216Metric'.
+Update J22 fields.
+Update J16 fields.
+Update U8 fields.
+Update C38 fields.
+Update U7 fields.
+Update C37 fields.
+Update U6 fields.
+Update C36 fields.
+Update U5 fields.
+Update C39 fields.
+Update C61 fields.
+Update C34 fields.
+Update U4 fields.
+Update U3 fields.
+Update C30 fields.
+Update U2 fields.
+Update U1 fields.
+Update L1 fields.
+Update C44 fields.
+Update J5 fields.
+Update C47 fields.
+Update C46 fields.
+Update U18 fields.
+Update U15 fields.
+Update C45 fields.
+Update U14 fields.
+Update J7 fields.
+Update J8 fields.
+Update C43 fields.
+Update U12 fields.
+Update C42 fields.
+Update C41 fields.
+Update J11 fields.
+Update J14 fields.
+Update C40 fields.
+Warning: No net found for component J5 pad MP (no pin MP in symbol).
+Warning: Via connected to unknown net ().
+Warning: Via connected to unknown net ().
+Warning: Via connected to unknown net ().
+Warning: Via connected to unknown net ().
+Warning: No net found for component J16 pad MP (no pin MP in symbol).
+Warning: No net found for component J5 pad MP (no pin MP in symbol).
+Warning: No net found for component J6 pad 17 (no pin 17 in symbol).
+Warning: No net found for component J6 pad 15 (no pin 15 in symbol).
+Warning: No net found for component J6 pad 16 (no pin 16 in symbol).
+Warning: No net found for component J6 pad 18 (no pin 18 in symbol).
+Warning: No net found for component J10 pad 15 (no pin 15 in symbol).
+Warning: No net found for component J10 pad 18 (no pin 18 in symbol).
+Warning: No net found for component J10 pad 16 (no pin 16 in symbol).
+Warning: No net found for component J10 pad 17 (no pin 17 in symbol).
+Warning: No net found for component J1 pad 16 (no pin 16 in symbol).
+Warning: No net found for component J14 pad MP (no pin MP in symbol).
+Warning: No net found for component J1 pad 18 (no pin 18 in symbol).
+Warning: No net found for component J14 pad MP (no pin MP in symbol).
+Warning: No net found for component J16 pad MP (no pin MP in symbol).
+Warning: No net found for component J17 pad 18 (no pin 18 in symbol).
+Warning: No net found for component J17 pad 17 (no pin 17 in symbol).
+Warning: No net found for component J17 pad 16 (no pin 16 in symbol).
+Warning: No net found for component J17 pad 15 (no pin 15 in symbol).
+Warning: No net found for component J1 pad 17 (no pin 17 in symbol).
+Warning: No net found for component J100 pad 1_2 (no pin 1_2 in symbol).
+Warning: No net found for component J100 pad 1_4 (no pin 1_4 in symbol).
+Warning: No net found for component J100 pad 1_1 (no pin 1_1 in symbol).
+Warning: No net found for component J100 pad 1_3 (no pin 1_3 in symbol).
+Warning: No net found for component J1 pad 15 (no pin 15 in symbol).
+Warning: No net found for component J101 pad 1_4 (no pin 1_4 in symbol).
+Warning: No net found for component J101 pad 1_2 (no pin 1_2 in symbol).
+Warning: No net found for component J101 pad 1_3 (no pin 1_3 in symbol).
+Warning: No net found for component J101 pad 1_1 (no pin 1_1 in symbol).
+Error: Cannot add BT1 (footprint 'CM5IO:BatteryHolder_Keystone_3034_1x20mm' not found).
+Error: Cannot update J4 (footprint 'CM5IO:M.2 M Key socket' not found).
+Error: Cannot update U9 (footprint 'CM5IO:LED-SMD_4P-L4.0-W1.6-L' not found).
+Error: Cannot update J5 (footprint 'CM5IO:Hirose_FH12-22S-0.5SH_1x22-1MP_P0.50mm_Horizontal' not found).
+Error: Cannot update J7 (footprint 'CM5IO:SDCARD_MOLEX_503398-1892' not found).
+Error: Cannot update J11 (footprint 'Connector_USB:USB_C_Receptacle_GCT_USB4105-GF-A_16P_TopMnt_Horizontal' not found).
+Error: Cannot update Module1 (footprint 'CM5IO:Raspberry-Pi-5-Compute-Module' not found).
+Error: Cannot update J22 (footprint 'CM5IO:EDAC 690-019-298-412' not found).
+Error: Cannot update U3 (footprint 'CM5IO:TRJG0926HENL' not found).
+Error: Cannot update L1 (footprint 'CM5IO:L_Bourns_SRP5030CC' not found).
+
+
+Info: Total warnings: 34, errors: 10.

--- a/CM5_GPIO.kicad_sch
+++ b/CM5_GPIO.kicad_sch
@@ -11559,6 +11559,16 @@
 	)
 	(wire
 		(pts
+			(xy 125.73 148.59) (xy 125.73 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "391983e8-445c-4638-86f0-3429eab62602")
+	)
+	(wire
+		(pts
 			(xy 166.37 46.99) (xy 165.1 46.99)
 		)
 		(stroke
@@ -11636,6 +11646,16 @@
 			(type solid)
 		)
 		(uuid "3c706a30-a30f-400b-bdc7-8a33c80e630b")
+	)
+	(wire
+		(pts
+			(xy 125.73 146.05) (xy 137.16 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd5dad4-b6c0-45cc-8887-d17963d367ba")
 	)
 	(wire
 		(pts
@@ -11946,6 +11966,16 @@
 			(type solid)
 		)
 		(uuid "572bf966-40b4-4074-84f8-0470619143e0")
+	)
+	(wire
+		(pts
+			(xy 134.62 153.67) (xy 137.16 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58357f48-c769-49ca-a870-e2784a009b1b")
 	)
 	(wire
 		(pts
@@ -12279,6 +12309,16 @@
 	)
 	(wire
 		(pts
+			(xy 134.62 148.59) (xy 137.16 148.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8038cbda-b4e2-4515-b523-285b0332a2b9")
+	)
+	(wire
+		(pts
 			(xy 100.33 52.07) (xy 114.3 52.07)
 		)
 		(stroke
@@ -12416,6 +12456,16 @@
 			(type solid)
 		)
 		(uuid "8b398452-7864-4ae1-87b2-f3c31f993db8")
+	)
+	(wire
+		(pts
+			(xy 129.54 151.13) (xy 137.16 151.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8bede8c6-a23b-442f-836a-6a24ec46a9f7")
 	)
 	(wire
 		(pts
@@ -14557,6 +14607,16 @@
 		)
 		(uuid "64ab901b-ea46-43a5-9f7f-64cceeb0129b")
 	)
+	(label "ID_SC"
+		(at 134.62 153.67 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "656bfea3-23e7-4d18-805b-cc4fe33e1b3b")
+	)
 	(label "TR2_TAP"
 		(at 246.38 64.77 180)
 		(effects
@@ -14576,6 +14636,16 @@
 			(justify right bottom)
 		)
 		(uuid "6dd24007-4e31-4437-a050-fa6e699c9468")
+	)
+	(label "ID_SD"
+		(at 129.54 151.13 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6f2c9907-eb8e-4a3a-ad41-c6948491d517")
 	)
 	(label "+1.8v"
 		(at 26.67 130.81 0)
@@ -14926,6 +14996,16 @@
 			(justify left bottom)
 		)
 		(uuid "adae4e92-033f-4af1-ab17-18d807cdc010")
+	)
+	(label "+3.3v"
+		(at 134.62 148.59 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "af4a789c-b6a6-46f1-a7f2-b8d74b2203b3")
 	)
 	(label "PWR_BUT"
 		(at 27.686 135.89 0)
@@ -20584,6 +20664,71 @@
 			(project "CM5IO"
 				(path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55/00000000-0000-0000-0000-00005cff706a"
 					(reference "U3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 125.73 148.59 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "288e1d00-99e3-4b28-910c-1acc6046b8ad")
+		(property "Reference" "#PWR039"
+			(at 125.73 154.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 125.857 152.9842 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 125.73 148.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 125.73 148.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 125.73 148.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9b2ed4e-9446-4295-8978-f645142c62ca")
+		)
+		(instances
+			(project "libreboard"
+				(path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55/00000000-0000-0000-0000-00005cff706a"
+					(reference "#PWR039")
 					(unit 1)
 				)
 			)

--- a/CM5_HighSpeed.kicad_sch
+++ b/CM5_HighSpeed.kicad_sch
@@ -22619,7 +22619,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" "Capacitor, AO-Cap, 100µF, ±20%, 10V, 10mΩ ESR"
+		(property "Part Description" "Capacitor, Aluminum, 100µF, ±20%, 10V, 10mΩ ESR"
 			(at 87.63 181.61 0)
 			(effects
 				(font
@@ -23974,7 +23974,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" "Capacitor, AO-Cap, 100µF, ±20%, 10V, 10mΩ ESR"
+		(property "Part Description" "Capacitor, Aluminum, 100µF, ±20%, 10V, 10mΩ ESR"
 			(at 247.65 105.41 0)
 			(effects
 				(font

--- a/libreboard.kicad_pro
+++ b/libreboard.kicad_pro
@@ -474,6 +474,7 @@
       "single_global_label": "ignore",
       "unannotated": "error",
       "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
       "unit_value_mismatch": "error",
       "unresolved_variable": "error",
       "wire_dangling": "error"

--- a/libreboard.kicad_sch
+++ b/libreboard.kicad_sch
@@ -9669,7 +9669,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at -13.97 358.14 0)
 			(effects
 				(font
@@ -9687,7 +9687,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05CR50J106MHTR-ND"
 			(at -13.97 358.14 0)
 			(effects
 				(font
@@ -9705,7 +9705,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D106MAT2A"
 			(at -13.97 358.14 0)
 			(effects
 				(font
@@ -9714,7 +9714,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at -13.97 358.14 0)
 			(effects
 				(font
@@ -9723,7 +9723,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 10µF, ±20%, 6.3V, X5R, 0402 (1005m)"
 			(at -13.97 358.14 0)
 			(effects
 				(font
@@ -9820,7 +9820,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/KGQ-Series.pdf"
 			(at 115.57 401.32 0)
 			(effects
 				(font
@@ -9838,7 +9838,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGQ05FCG1H1R0BHTR-ND"
 			(at 115.57 401.32 0)
 			(effects
 				(font
@@ -9856,7 +9856,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04025U1R0BAT2A"
 			(at 115.57 401.32 0)
 			(effects
 				(font
@@ -9865,7 +9865,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 115.57 401.32 0)
 			(effects
 				(font
@@ -9874,7 +9874,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 1pF, ±10%, 50V, C0G/NP0, 0402 (1005m)"
 			(at 115.57 401.32 0)
 			(effects
 				(font
@@ -9971,7 +9971,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at -2.54 246.38 0)
 			(effects
 				(font
@@ -9989,7 +9989,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05AR50J105KHTR-ND"
 			(at -2.54 246.38 0)
 			(effects
 				(font
@@ -10007,7 +10007,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D105KAT2A"
 			(at -2.54 246.38 0)
 			(effects
 				(font
@@ -10016,7 +10016,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at -2.54 246.38 0)
 			(effects
 				(font
@@ -10025,7 +10025,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at -2.54 246.38 0)
 			(effects
 				(font
@@ -10121,7 +10121,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "PTPS55289RYQR"
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/tps55289.pdf"
 			(at 45.72 243.84 0)
 			(effects
 				(font
@@ -10168,6 +10168,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at 45.72 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "296-TPS55289RYQRTR-ND"
+			(at 45.72 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at 45.72 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "TPS55289RYQR"
+			(at 45.72 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Texas Instruments"
+			(at 45.72 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "IC, Buck Boost, 0.8v, 1-output, 8A"
 			(at 45.72 243.84 0)
 			(effects
 				(font
@@ -10350,7 +10395,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/AAB8000/AAB8000C193.pdf"
 			(at 179.07 393.7 0)
 			(effects
 				(font
@@ -10396,6 +10441,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at 179.07 393.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "P16432TR-ND"
+			(at 179.07 393.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at 179.07 393.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "10SVP270M"
+			(at 179.07 393.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Panasonic"
+			(at 179.07 393.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "Capacitor, Aluminum, 270µF, ±20%, 10V, 25mΩ ESR"
 			(at 179.07 393.7 0)
 			(effects
 				(font
@@ -10502,6 +10592,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at 175.26 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "P122099TR-ND"
+			(at 175.26 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at 175.26 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "20SVF56M"
+			(at 175.26 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Panasonic"
+			(at 175.26 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "Capacitor, Aluminum, 56µF, ±20%, 20V, 30mΩ ESR"
 			(at 175.26 281.94 0)
 			(effects
 				(font
@@ -10713,7 +10848,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10722,7 +10857,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.digikey.com/en/products/detail/kyocera-avx/12065C475KAT2A/2676431"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10740,7 +10875,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM31AR71H475KUTR-ND"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10758,7 +10893,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" " 12065C475KAT2A"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10767,7 +10902,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10776,7 +10911,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 4.7µF, ±10%, 50V, X7R, 1206 (3216m)"
 			(at -11.43 276.86 0)
 			(effects
 				(font
@@ -10873,7 +11008,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDA0000/AOA0000C304.pdf"
 			(at 10.16 307.34 0)
 			(effects
 				(font
@@ -10891,7 +11026,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "P48.7KLTR-ND"
 			(at 10.16 307.34 0)
 			(effects
 				(font
@@ -10909,7 +11044,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-2RKF4872X"
 			(at 10.16 307.34 0)
 			(effects
 				(font
@@ -10918,7 +11053,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 10.16 307.34 0)
 			(effects
 				(font
@@ -10927,7 +11062,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 48.7kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 10.16 307.34 0)
 			(effects
 				(font
@@ -11024,7 +11159,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.we-online.com/components/products/datasheet/885012005011.pdf"
 			(at 142.24 393.7 0)
 			(effects
 				(font
@@ -11042,7 +11177,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "732-7429-2-ND"
 			(at 142.24 393.7 0)
 			(effects
 				(font
@@ -11060,7 +11195,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "885012005011"
 			(at 142.24 393.7 0)
 			(effects
 				(font
@@ -11069,7 +11204,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Würth Elektronik"
 			(at 142.24 393.7 0)
 			(effects
 				(font
@@ -11078,7 +11213,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 47pF, ±5%, 10V, C0G/NP0, 0402 (1005m)"
 			(at 142.24 393.7 0)
 			(effects
 				(font
@@ -11175,7 +11310,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/X7RDielectric.pdf"
 			(at 101.6 401.32 0)
 			(effects
 				(font
@@ -11193,7 +11328,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-1098-2-ND"
 			(at 101.6 401.32 0)
 			(effects
 				(font
@@ -11211,7 +11346,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04025C561KAT2A"
 			(at 101.6 401.32 0)
 			(effects
 				(font
@@ -11220,7 +11355,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 101.6 401.32 0)
 			(effects
 				(font
@@ -11229,7 +11364,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 560pF, ±10%, 50V, X7R, 0402 (1005m)"
 			(at 101.6 401.32 0)
 			(effects
 				(font
@@ -12738,7 +12873,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.we-online.com/components/products/datasheet/885012005011.pdf"
 			(at 153.67 393.7 0)
 			(effects
 				(font
@@ -12756,7 +12891,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "732-7429-2-ND"
 			(at 153.67 393.7 0)
 			(effects
 				(font
@@ -12774,7 +12909,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "885012005011"
 			(at 153.67 393.7 0)
 			(effects
 				(font
@@ -12783,7 +12918,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Würth Elektronik"
 			(at 153.67 393.7 0)
 			(effects
 				(font
@@ -12792,7 +12927,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 47pF, ±5%, 10V, C0G/NP0, 0402 (1005m)"
 			(at 153.67 393.7 0)
 			(effects
 				(font
@@ -12889,7 +13024,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/KGM_X7R.pdf"
 			(at 97.79 289.56 0)
 			(effects
 				(font
@@ -12907,7 +13042,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05AR71H471KHTR-ND "
 			(at 97.79 289.56 0)
 			(effects
 				(font
@@ -12925,7 +13060,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "KGM05AR71H471KH"
 			(at 97.79 289.56 0)
 			(effects
 				(font
@@ -12934,7 +13069,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 97.79 289.56 0)
 			(effects
 				(font
@@ -12943,7 +13078,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 470pF, ±10%, 50V, X7R, 0402 (1005m)"
 			(at 97.79 289.56 0)
 			(effects
 				(font
@@ -13040,7 +13175,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDP0000/AOA0000C334.pdf"
 			(at 16.51 251.46 0)
 			(effects
 				(font
@@ -13058,7 +13193,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "10-ERJ-U02F1003XTR-ND"
 			(at 16.51 251.46 0)
 			(effects
 				(font
@@ -13076,7 +13211,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-U02F1003X"
 			(at 16.51 251.46 0)
 			(effects
 				(font
@@ -13085,7 +13220,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 16.51 251.46 0)
 			(effects
 				(font
@@ -13094,7 +13229,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 100kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 16.51 251.46 0)
 			(effects
 				(font
@@ -13876,7 +14011,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at 1.27 358.14 0)
 			(effects
 				(font
@@ -13894,7 +14029,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05AR50J105KHTR-ND"
 			(at 1.27 358.14 0)
 			(effects
 				(font
@@ -13912,7 +14047,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D105KAT2A"
 			(at 1.27 358.14 0)
 			(effects
 				(font
@@ -13921,7 +14056,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 1.27 358.14 0)
 			(effects
 				(font
@@ -13930,7 +14065,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 1.27 358.14 0)
 			(effects
 				(font
@@ -14158,7 +14293,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at 125.73 281.94 0)
 			(effects
 				(font
@@ -14176,7 +14311,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05AR50J105KHTR-ND"
 			(at 125.73 281.94 0)
 			(effects
 				(font
@@ -14194,7 +14329,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D105KAT2A"
 			(at 125.73 281.94 0)
 			(effects
 				(font
@@ -14203,7 +14338,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 125.73 281.94 0)
 			(effects
 				(font
@@ -14212,7 +14347,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 125.73 281.94 0)
 			(effects
 				(font
@@ -14309,7 +14444,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.yageogroup.com/content/datasheet/asset/file/KEM_A4088_A768"
 			(at -30.48 358.14 0)
 			(effects
 				(font
@@ -14355,6 +14490,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at -30.48 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "399-A768EB226M1HLAE048TR-ND"
+			(at -30.48 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at -30.48 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "A768EB226M1HLAE048"
+			(at -30.48 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Kemet"
+			(at -30.48 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "Capacitor, Aluminum, 22µF, ±20%, 50V, 48mΩ ESR"
 			(at -30.48 358.14 0)
 			(effects
 				(font
@@ -14609,7 +14789,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDA0000/AOA0000C304.pdf"
 			(at 97.79 303.53 0)
 			(effects
 				(font
@@ -14627,7 +14807,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "P105KLTR-ND"
 			(at 97.79 303.53 0)
 			(effects
 				(font
@@ -14645,7 +14825,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-2RKF1053X"
 			(at 97.79 303.53 0)
 			(effects
 				(font
@@ -14654,7 +14834,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 97.79 303.53 0)
 			(effects
 				(font
@@ -14663,7 +14843,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" "50 mW"
+		(property "Part Description" "Resistor, 105kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 97.79 303.53 0)
 			(effects
 				(font
@@ -14760,7 +14940,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at 129.54 393.7 0)
 			(effects
 				(font
@@ -14778,7 +14958,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05AR50J105KHTR-ND"
 			(at 129.54 393.7 0)
 			(effects
 				(font
@@ -14796,7 +14976,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D105KAT2A"
 			(at 129.54 393.7 0)
 			(effects
 				(font
@@ -14805,7 +14985,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 129.54 393.7 0)
 			(effects
 				(font
@@ -14814,7 +14994,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 129.54 393.7 0)
 			(effects
 				(font
@@ -15585,7 +15765,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.vishay.com/docs/20035/dcrcwe3.pdf"
 			(at 13.97 419.1 0)
 			(effects
 				(font
@@ -15603,7 +15783,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "541-CRCW040250K0FKEDTR-ND"
 			(at 13.97 419.1 0)
 			(effects
 				(font
@@ -15621,7 +15801,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "CRCW040250K0FKED"
 			(at 13.97 419.1 0)
 			(effects
 				(font
@@ -15630,7 +15810,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Vishay Dale"
 			(at 13.97 419.1 0)
 			(effects
 				(font
@@ -15639,7 +15819,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 50kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 13.97 419.1 0)
 			(effects
 				(font
@@ -15859,7 +16039,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -15868,7 +16048,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.digikey.com/en/products/detail/kyocera-avx/12065C475KAT2A/2676431"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -15886,7 +16066,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM31AR71H475KUTR-ND"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -15904,7 +16084,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" " 12065C475KAT2A"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -15913,7 +16093,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -15922,7 +16102,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 4.7µF, ±10%, 50V, X7R, 1206 (3216m)"
 			(at -7.62 388.62 0)
 			(effects
 				(font
@@ -16019,7 +16199,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r.pdf"
 			(at 129.54 238.76 0)
 			(effects
 				(font
@@ -16037,7 +16217,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-11504-2-ND"
 			(at 129.54 238.76 0)
 			(effects
 				(font
@@ -16055,7 +16235,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D104KAT4A"
 			(at 129.54 238.76 0)
 			(effects
 				(font
@@ -16064,7 +16244,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 129.54 238.76 0)
 			(effects
 				(font
@@ -16073,7 +16253,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 0.1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 129.54 238.76 0)
 			(effects
 				(font
@@ -16170,7 +16350,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r.pdf"
 			(at 100.33 349.25 0)
 			(effects
 				(font
@@ -16188,7 +16368,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-11504-2-ND"
 			(at 100.33 349.25 0)
 			(effects
 				(font
@@ -16206,7 +16386,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D104KAT4A"
 			(at 100.33 349.25 0)
 			(effects
 				(font
@@ -16215,7 +16395,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 100.33 349.25 0)
 			(effects
 				(font
@@ -16224,7 +16404,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 0.1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 100.33 349.25 0)
 			(effects
 				(font
@@ -16627,7 +16807,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "PTPS55289RYQR"
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/tps55289.pdf"
 			(at 49.53 355.6 0)
 			(effects
 				(font
@@ -16674,6 +16854,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at 49.53 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "296-TPS55289RYQRTR-ND"
+			(at 49.53 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at 49.53 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "TPS55289RYQR"
+			(at 49.53 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Texas Instruments"
+			(at 49.53 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "IC, Buck Boost, 0.8v, 1-output, 8A"
 			(at 49.53 355.6 0)
 			(effects
 				(font
@@ -16939,7 +17164,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r.pdf"
 			(at 133.35 350.52 0)
 			(effects
 				(font
@@ -16957,7 +17182,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-11504-2-ND"
 			(at 133.35 350.52 0)
 			(effects
 				(font
@@ -16975,7 +17200,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D104KAT4A"
 			(at 133.35 350.52 0)
 			(effects
 				(font
@@ -16984,7 +17209,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 133.35 350.52 0)
 			(effects
 				(font
@@ -16993,7 +17218,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 0.1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 133.35 350.52 0)
 			(effects
 				(font
@@ -17156,7 +17381,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/C0GNP0-KGM.pdf"
 			(at 111.76 289.56 0)
 			(effects
 				(font
@@ -17174,7 +17399,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05ACG1H3R9BHTR-ND"
 			(at 111.76 289.56 0)
 			(effects
 				(font
@@ -17192,7 +17417,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "KGM05ACG1H3R9BH"
 			(at 111.76 289.56 0)
 			(effects
 				(font
@@ -17201,7 +17426,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 111.76 289.56 0)
 			(effects
 				(font
@@ -17210,7 +17435,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 3.9pF, ±2.5%, 50V, C0G/NP0, 0402 (1005m)"
 			(at 111.76 289.56 0)
 			(effects
 				(font
@@ -17307,7 +17532,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r-KGM.pdf"
 			(at -17.78 246.38 0)
 			(effects
 				(font
@@ -17325,7 +17550,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-KGM05CR50J106MHTR-ND"
 			(at -17.78 246.38 0)
 			(effects
 				(font
@@ -17343,7 +17568,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D106MAT2A"
 			(at -17.78 246.38 0)
 			(effects
 				(font
@@ -17352,7 +17577,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at -17.78 246.38 0)
 			(effects
 				(font
@@ -17361,7 +17586,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 10µF, ±20%, 6.3V, X5R, 0402 (1005m)"
 			(at -17.78 246.38 0)
 			(effects
 				(font
@@ -17458,7 +17683,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDA0000/AOA0000C304.pdf"
 			(at 16.51 245.11 0)
 			(effects
 				(font
@@ -17476,7 +17701,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "P887KLTR-ND"
 			(at 16.51 245.11 0)
 			(effects
 				(font
@@ -17494,7 +17719,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-2RKF8873X"
 			(at 16.51 245.11 0)
 			(effects
 				(font
@@ -17503,7 +17728,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 16.51 245.11 0)
 			(effects
 				(font
@@ -17512,7 +17737,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 887kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 16.51 245.11 0)
 			(effects
 				(font
@@ -17609,7 +17834,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDP0000/AOA0000C334.pdf"
 			(at 20.32 363.22 0)
 			(effects
 				(font
@@ -17627,7 +17852,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "10-ERJ-U02F1003XTR-ND"
 			(at 20.32 363.22 0)
 			(effects
 				(font
@@ -17645,7 +17870,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-U02F1003X"
 			(at 20.32 363.22 0)
 			(effects
 				(font
@@ -17654,7 +17879,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 20.32 363.22 0)
 			(effects
 				(font
@@ -17663,7 +17888,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 100kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 20.32 363.22 0)
 			(effects
 				(font
@@ -17760,7 +17985,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDA0000/AOA0000C304.pdf"
 			(at 20.32 356.87 0)
 			(effects
 				(font
@@ -17778,7 +18003,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "P887KLTR-ND"
 			(at 20.32 356.87 0)
 			(effects
 				(font
@@ -17796,7 +18021,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-2RKF8873X"
 			(at 20.32 356.87 0)
 			(effects
 				(font
@@ -17805,7 +18030,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 20.32 356.87 0)
 			(effects
 				(font
@@ -17814,7 +18039,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Resistor, 887kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 20.32 356.87 0)
 			(effects
 				(font
@@ -17911,7 +18136,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://datasheets.kyocera-avx.com/cx5r.pdf"
 			(at 96.52 237.49 0)
 			(effects
 				(font
@@ -17929,7 +18154,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "478-11504-2-ND"
 			(at 96.52 237.49 0)
 			(effects
 				(font
@@ -17947,7 +18172,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "04026D104KAT4A"
 			(at 96.52 237.49 0)
 			(effects
 				(font
@@ -17956,7 +18181,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Kyocera"
 			(at 96.52 237.49 0)
 			(effects
 				(font
@@ -17965,7 +18190,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 0.1µF, ±10%, 6.3V, X5R, 0402 (1005m)"
 			(at 96.52 237.49 0)
 			(effects
 				(font
@@ -18771,7 +18996,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "https://www.yageogroup.com/content/datasheet/asset/file/KEM_A4088_A768"
+		(property "Datasheet" "https://search.kemet.com/download/specsheet/A770KE396M1HLAS042"
 			(at -34.29 246.38 0)
 			(effects
 				(font
@@ -18817,6 +19042,51 @@
 			)
 		)
 		(property "STANDARD" ""
+			(at -34.29 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Dist. P/N" "399-A770KE396M1HLAS042TR-ND"
+			(at -34.29 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Distributor" "Digikey"
+			(at -34.29 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manf. P/N" "A770KE396M1HLAS042"
+			(at -34.29 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Kemet"
+			(at -34.29 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Part Description" "Capacitor, Aluminum, 39µF, ±20%, 50V, 42mΩ ESR"
 			(at -34.29 246.38 0)
 			(effects
 				(font
@@ -18877,7 +19147,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://industrial.panasonic.com/cdbs/www-data/pdf/RDA0000/AOA0000C304.pdf"
 			(at 101.6 415.29 0)
 			(effects
 				(font
@@ -18895,7 +19165,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "P105KLTR-ND"
 			(at 101.6 415.29 0)
 			(effects
 				(font
@@ -18913,7 +19183,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "ERJ-2RKF1053X"
 			(at 101.6 415.29 0)
 			(effects
 				(font
@@ -18922,7 +19192,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Panasonic"
 			(at 101.6 415.29 0)
 			(effects
 				(font
@@ -18931,7 +19201,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" "50 mW"
+		(property "Part Description" "Resistor, 105kΩ, ±1%, 0.1W, SMD 0402 (1005m)"
 			(at 101.6 415.29 0)
 			(effects
 				(font
@@ -19028,7 +19298,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
+		(property "Datasheet" "https://www.we-online.com/components/products/datasheet/885012005011.pdf"
 			(at 163.83 393.7 0)
 			(effects
 				(font
@@ -19046,7 +19316,7 @@
 				(hide yes)
 			)
 		)
-		(property "Dist. P/N" ""
+		(property "Dist. P/N" "732-7429-2-ND"
 			(at 163.83 393.7 0)
 			(effects
 				(font
@@ -19064,7 +19334,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manf. P/N" ""
+		(property "Manf. P/N" "885012005011"
 			(at 163.83 393.7 0)
 			(effects
 				(font
@@ -19073,7 +19343,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" ""
+		(property "Manufacturer" "Würth Elektronik"
 			(at 163.83 393.7 0)
 			(effects
 				(font
@@ -19082,7 +19352,7 @@
 				(hide yes)
 			)
 		)
-		(property "Part Description" ""
+		(property "Part Description" "Capacitor, Ceramic, 47pF, ±5%, 10V, C0G/NP0, 0402 (1005m)"
 			(at 163.83 393.7 0)
 			(effects
 				(font

--- a/libreboard.kicad_sch
+++ b/libreboard.kicad_sch
@@ -5182,6 +5182,16 @@
 	)
 	(wire
 		(pts
+			(xy 39.37 266.7) (xy 45.72 266.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0db9fe78-7ab8-45e9-9874-8a1842c6ce56")
+	)
+	(wire
+		(pts
 			(xy 101.6 433.07) (xy 115.57 433.07)
 		)
 		(stroke
@@ -6732,6 +6742,16 @@
 	)
 	(wire
 		(pts
+			(xy 43.18 383.54) (xy 49.53 383.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "85f053f1-aad8-4c02-8be6-91d60246ea25")
+	)
+	(wire
+		(pts
 			(xy 45.72 261.62) (xy 29.21 261.62)
 		)
 		(stroke
@@ -6909,6 +6929,16 @@
 			(type solid)
 		)
 		(uuid "909b030b-fa1a-4fe8-b1ee-422b4d9e23cf")
+	)
+	(wire
+		(pts
+			(xy 39.37 271.78) (xy 45.72 271.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91b4ec6c-473e-4099-a111-61be441c89a1")
 	)
 	(wire
 		(pts
@@ -7772,6 +7802,16 @@
 	)
 	(wire
 		(pts
+			(xy 43.18 378.46) (xy 49.53 378.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3827236-1748-4e47-9d99-707ee6147348")
+	)
+	(wire
+		(pts
 			(xy 58.42 114.3) (xy 66.04 114.3)
 		)
 		(stroke
@@ -8360,6 +8400,16 @@
 		)
 		(uuid "28c76331-1bb2-429e-88ba-1bacab9de126")
 	)
+	(label "ID_SC"
+		(at 39.37 266.7 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "28f617d0-b8b5-492a-a46b-c71f653fde43")
+	)
 	(label "CC2"
 		(at 119.38 133.35 0)
 		(effects
@@ -8400,6 +8450,36 @@
 		)
 		(uuid "5740c959-93d8-47fd-8f68-62f0109e753d")
 	)
+	(label "ID_SC"
+		(at 149.86 109.22 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "62aed552-6209-4ac6-a2f1-581388f9767e")
+	)
+	(label "ID_SC"
+		(at 43.18 378.46 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6e28e04c-b79b-4a51-955e-051799cf2aef")
+	)
+	(label "ID_SD"
+		(at 39.37 271.78 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "76dabc1d-a428-447a-b48b-15bffd8634e0")
+	)
 	(label "USB2_P"
 		(at 74.93 62.23 180)
 		(effects
@@ -8419,6 +8499,16 @@
 			(justify left bottom)
 		)
 		(uuid "7d5a2b2f-0ea3-4086-b538-65807005ae2a")
+	)
+	(label "ID_SD"
+		(at 146.05 109.22 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "833a6772-c97b-45bd-9493-15e6cc8ab6f3")
 	)
 	(label "USB2_N"
 		(at 74.93 57.15 180)
@@ -8479,6 +8569,16 @@
 			(justify left bottom)
 		)
 		(uuid "d4106691-9af4-4d1a-b5eb-d17aeb47a3f6")
+	)
+	(label "ID_SD"
+		(at 43.18 383.54 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ef7c1121-f974-4231-b5d8-5054c9c93f4b")
 	)
 	(symbol
 		(lib_id "Mechanical:MountingHole")
@@ -12135,7 +12235,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric"
 			(at 149.86 281.94 0)
 			(effects
 				(font
@@ -12713,7 +12813,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric"
 			(at 160.02 281.94 0)
 			(effects
 				(font
@@ -19440,7 +19540,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric"
 			(at 138.43 281.94 0)
 			(effects
 				(font


### PR DESCRIPTION
This PR updates the new component fields in the BOM for the voltage regulator upgrade. The PCB has been synchronized from the schematic, however there were a few warnings and errors. The error report is included in the root: "250916_schematic-pcb-error-report.txt". One item remains to be identified on the BOM, reference C27-C29, if we can use a 1206 footprint then I suggest we go with [this capacitor](https://www.digikey.com/en/products/detail/tdk-corporation/C3216X5R1E336M160AC/2792259). Otherwise, we may want to consider a through-board component like [this](https://www.digikey.com/en/products/detail/tdk-corporation/FG22X7R1C336MRT06/5802930).